### PR TITLE
Remove unused ffmpeg-next dependency

### DIFF
--- a/vrifa-rs/Cargo.lock
+++ b/vrifa-rs/Cargo.lock
@@ -98,24 +98,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,15 +146,6 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -367,31 +340,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ffmpeg-next"
-version = "8.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c4bd5ab1ac61f29c634df1175d350ded29cf74c3c6d4f7030431a5ae3c7d5d"
-dependencies = [
- "bitflags",
- "ffmpeg-sys-next",
- "libc",
-]
-
-[[package]]
-name = "ffmpeg-sys-next"
-version = "8.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a314bc0e022a33a99567ed4bd2576bd58ffd8fcff7891c29194cfecc26a62547"
-dependencies = [
- "bindgen",
- "cc",
- "libc",
- "num_cpus",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,12 +421,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,15 +474,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itoa"
@@ -609,12 +542,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,16 +593,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,16 +627,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -1271,7 +1178,6 @@ name = "vrifa-io"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ffmpeg-next",
  "image",
  "ndarray",
  "opencv",

--- a/vrifa-rs/Cargo.toml
+++ b/vrifa-rs/Cargo.toml
@@ -17,7 +17,6 @@ repository = "https://github.com/j-vaught/vrifa"
 anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 clap = { version = "4.5", features = ["derive"] }
-ffmpeg-next = "8.1"
 image = { version = "0.25", default-features = false, features = ["png"] }
 indexmap = { version = "2", features = ["serde"] }
 ndarray = { version = "0.17", features = ["rayon", "serde"] }

--- a/vrifa-rs/crates/vrifa-io/Cargo.toml
+++ b/vrifa-rs/crates/vrifa-io/Cargo.toml
@@ -6,7 +6,6 @@ license.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-ffmpeg-next.workspace = true
 image.workspace = true
 ndarray.workspace = true
 opencv = { workspace = true, features = ["videoio", "imgcodecs", "imgproc"] }

--- a/vrifa-rs/crates/vrifa-io/src/lib.rs
+++ b/vrifa-rs/crates/vrifa-io/src/lib.rs
@@ -19,10 +19,6 @@ pub struct VideoMetadata {
     pub height: usize,
 }
 
-pub fn init_ffmpeg() {
-    let _ = ffmpeg_next::init();
-}
-
 pub struct VideoReader {
     capture: videoio::VideoCapture,
     metadata: VideoMetadata,
@@ -31,7 +27,6 @@ pub struct VideoReader {
 
 impl VideoReader {
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
-        init_ffmpeg();
         let path = path.as_ref();
         let capture = videoio::VideoCapture::from_file_def(&path.to_string_lossy())
             .with_context(|| format!("opening video {}", path.display()))?;


### PR DESCRIPTION
## Summary
- Drop `ffmpeg-next` from workspace `Cargo.toml` and from `vrifa-io/Cargo.toml`.
- Delete the unused `init_ffmpeg()` no-op and its single call site in `vrifa-io/src/lib.rs`.
- Active encoder/decoder path unchanged: still OpenCV `VideoCapture` / `VideoWriter`.

## Test plan
- [x] `cargo build --release -p vrifa-cli`
- [x] `cargo tree -p vrifa-io | grep -i ffmpeg` prints nothing
- [x] `Cargo.lock` no longer contains `ffmpeg-next`
- [x] `cargo test --workspace --release`
- [x] `python3 tools/compare_runs.py` green on input_1 and input_2
- [x] Advisory MP4 metrics unchanged (5.048917 / 3.539831 input_1, 4.250483 / 3.534062 input_2)
- [x] `cargo bench -p vrifa-cli --bench perf_gate` passed (input_1: 32.778 s, input_2: 4.047 s)