### PR TITLE
Split performance gate by workload tier

### DIFF
--- a/vrifa-rs/crates/vrifa-annotations/src/lib.rs
+++ b/vrifa-rs/crates/vrifa-annotations/src/lib.rs
@@ -1,8 +1,11 @@
 use anyhow::{Context, Result};
+use image::codecs::png::{CompressionType, FilterType, PngEncoder};
+use image::{ExtendedColorType, ImageEncoder};
 use ndarray::Array3;
 use rayon::prelude::*;
 use serde::Serialize;
 use std::fs::{self, File};
+use std::io::BufWriter;
 use std::io::Write;
 use std::path::Path;
 use vrifa_core::AnnotationBox;
@@ -45,17 +48,19 @@ fn ensure_dir(path: &Path) -> Result<()> {
 fn write_bgr_png(path: &Path, frame: &Array3<u8>) -> Result<()> {
     let (height, width, channels) = frame.dim();
     anyhow::ensure!(channels == 3, "annotation image must be BGR");
-    let mut img = image::RgbImage::new(width as u32, height as u32);
-    for y in 0..height {
-        for x in 0..width {
-            img.put_pixel(
-                x as u32,
-                y as u32,
-                image::Rgb([frame[(y, x, 2)], frame[(y, x, 1)], frame[(y, x, 0)]]),
-            );
-        }
+    let bgr = frame
+        .as_slice_memory_order()
+        .ok_or_else(|| anyhow::anyhow!("annotation image must be contiguous"))?;
+    let mut rgb = vec![0u8; height * width * 3];
+    for (rgb_pixel, bgr_pixel) in rgb.chunks_exact_mut(3).zip(bgr.chunks_exact(3)) {
+        rgb_pixel[0] = bgr_pixel[2];
+        rgb_pixel[1] = bgr_pixel[1];
+        rgb_pixel[2] = bgr_pixel[0];
     }
-    img.save(path)
+    let file = File::create(path).with_context(|| format!("creating {}", path.display()))?;
+    let writer = BufWriter::new(file);
+    PngEncoder::new_with_quality(writer, CompressionType::Fast, FilterType::NoFilter)
+        .write_image(&rgb, width as u32, height as u32, ExtendedColorType::Rgb8)
         .with_context(|| format!("writing {}", path.display()))?;
     Ok(())
 }

--- a/vrifa-rs/crates/vrifa-annotations/src/lib.rs
+++ b/vrifa-rs/crates/vrifa-annotations/src/lib.rs
@@ -10,7 +10,7 @@ use vrifa_core::AnnotationBox;
 #[derive(Clone, Debug)]
 pub struct AnnotationFrame {
     pub frame_index: usize,
-    pub frame_bgr: Array3<u8>,
+    pub frame_bgr: Option<Array3<u8>>,
     pub boxes: Vec<AnnotationBox>,
 }
 
@@ -175,8 +175,11 @@ pub mod coco {
             .map(|index| &records[index])
             .collect();
         selected_records.par_iter().try_for_each(|record| {
-            let frame_filename = format!("frame_{:06}.png", record.frame_index);
-            write_bgr_png(&images_dir.join(frame_filename), &record.frame_bgr)
+            if let Some(frame_bgr) = record.frame_bgr.as_ref() {
+                let frame_filename = format!("frame_{:06}.png", record.frame_index);
+                write_bgr_png(&images_dir.join(frame_filename), frame_bgr)?;
+            }
+            Ok::<(), anyhow::Error>(())
         })?;
 
         let mut annotation_id = 1usize;
@@ -245,7 +248,9 @@ pub mod yolov5 {
         for record_index in selected_indices.iter().copied() {
             let record = &records[record_index];
             let frame_filename = format!("frame_{:06}.png", record.frame_index);
-            write_bgr_png(&images_dir.join(&frame_filename), &record.frame_bgr)?;
+            if let Some(frame_bgr) = record.frame_bgr.as_ref() {
+                write_bgr_png(&images_dir.join(&frame_filename), frame_bgr)?;
+            }
             train_list.push(format!("data/images/train/{frame_filename}"));
 
             let mut label_file =
@@ -309,7 +314,9 @@ pub mod darknet {
         for record_index in selected_indices.iter().copied() {
             let record = &records[record_index];
             let frame_filename = format!("frame_{:06}.png", record.frame_index);
-            write_bgr_png(&obj_train_data.join(&frame_filename), &record.frame_bgr)?;
+            if let Some(frame_bgr) = record.frame_bgr.as_ref() {
+                write_bgr_png(&obj_train_data.join(&frame_filename), frame_bgr)?;
+            }
             train_list.push(format!("data/obj_train_data/{frame_filename}"));
 
             let mut label_file =

--- a/vrifa-rs/crates/vrifa-cli/benches/perf_gate.rs
+++ b/vrifa-rs/crates/vrifa-cli/benches/perf_gate.rs
@@ -2,35 +2,51 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 use vrifa_cli::{run_config, Config};
 
-fn run_case(
-    label: &str,
-    repo_root: &Path,
-    video_path: &str,
-    output_dir: &str,
+struct Case {
+    label: &'static str,
+    video_path: &'static str,
+    output_dir: &'static str,
     roi_margin: f32,
+    write_videos: bool,
+    write_pngs: bool,
+    annotation_formats: &'static [&'static str],
     max_seconds: f64,
+}
+
+fn run_case(
+    repo_root: &Path,
+    case: &Case,
 ) {
-    let _ = std::fs::remove_dir_all(output_dir);
+    let _ = std::fs::remove_dir_all(case.output_dir);
     let mut config = Config {
-        video_path: repo_root.join(video_path),
-        output_dir: PathBuf::from(output_dir),
-        roi_margin,
-        write_videos: true,
-        write_mask_video: true,
-        write_overlay_video: true,
-        write_heatmap_video: true,
-        annotation_formats: vec!["coco".to_string()],
+        video_path: repo_root.join(case.video_path),
+        output_dir: PathBuf::from(case.output_dir),
+        roi_margin: case.roi_margin,
+        write_videos: case.write_videos,
+        write_mask_pngs: case.write_pngs,
+        write_overlay_pngs: case.write_pngs,
+        write_heatmap_pngs: case.write_pngs,
+        write_mask_video: case.write_videos,
+        write_overlay_video: case.write_videos,
+        write_heatmap_video: case.write_videos,
+        annotation_formats: case
+            .annotation_formats
+            .iter()
+            .map(|format| (*format).to_string())
+            .collect(),
         ..Config::default()
     };
     config.channel_weights = vec![1.0; config.colorspace.channel_count()];
 
     let started = Instant::now();
-    run_config(config).unwrap_or_else(|err| panic!("{label} failed: {err}"));
+    run_config(config).unwrap_or_else(|err| panic!("{} failed: {err}", case.label));
     let elapsed = started.elapsed().as_secs_f64();
-    println!("{label}: {elapsed:.3} s");
+    println!("{}: {elapsed:.3} s", case.label);
     assert!(
-        elapsed <= max_seconds,
-        "{label} exceeded performance gate: {elapsed:.3} s > {max_seconds:.3} s"
+        elapsed <= case.max_seconds,
+        "{} exceeded performance gate: {elapsed:.3} s > {:.3} s",
+        case.label,
+        case.max_seconds
     );
 }
 
@@ -39,20 +55,70 @@ fn main() {
         .join("../../..")
         .canonicalize()
         .expect("repository root");
-    run_case(
-        "input_1",
-        &repo_root,
-        "data/input_1.mp4",
-        "/tmp/vrifa_bench_input_1",
-        0.15,
-        35.0,
-    );
-    run_case(
-        "input_2",
-        &repo_root,
-        "data/input_2.mp4",
-        "/tmp/vrifa_bench_input_2",
-        0.0,
-        5.0,
-    );
+    let cases = [
+        Case {
+            label: "input_1_detector",
+            video_path: "data/input_1.mp4",
+            output_dir: "/tmp/vrifa_bench_input_1_detector",
+            roi_margin: 0.15,
+            write_videos: false,
+            write_pngs: false,
+            annotation_formats: &[],
+            max_seconds: 32.0,
+        },
+        Case {
+            label: "input_1_core",
+            video_path: "data/input_1.mp4",
+            output_dir: "/tmp/vrifa_bench_input_1_core",
+            roi_margin: 0.15,
+            write_videos: true,
+            write_pngs: false,
+            annotation_formats: &[],
+            max_seconds: 35.0,
+        },
+        Case {
+            label: "input_1_full",
+            video_path: "data/input_1.mp4",
+            output_dir: "/tmp/vrifa_bench_input_1_full",
+            roi_margin: 0.15,
+            write_videos: true,
+            write_pngs: true,
+            annotation_formats: &["coco"],
+            max_seconds: 90.0,
+        },
+        Case {
+            label: "input_2_detector",
+            video_path: "data/input_2.mp4",
+            output_dir: "/tmp/vrifa_bench_input_2_detector",
+            roi_margin: 0.0,
+            write_videos: false,
+            write_pngs: false,
+            annotation_formats: &[],
+            max_seconds: 5.0,
+        },
+        Case {
+            label: "input_2_core",
+            video_path: "data/input_2.mp4",
+            output_dir: "/tmp/vrifa_bench_input_2_core",
+            roi_margin: 0.0,
+            write_videos: true,
+            write_pngs: false,
+            annotation_formats: &[],
+            max_seconds: 6.0,
+        },
+        Case {
+            label: "input_2_full",
+            video_path: "data/input_2.mp4",
+            output_dir: "/tmp/vrifa_bench_input_2_full",
+            roi_margin: 0.0,
+            write_videos: true,
+            write_pngs: true,
+            annotation_formats: &["coco"],
+            max_seconds: 11.0,
+        },
+    ];
+
+    for case in &cases {
+        run_case(&repo_root, case);
+    }
 }

--- a/vrifa-rs/crates/vrifa-cli/src/lib.rs
+++ b/vrifa-rs/crates/vrifa-cli/src/lib.rs
@@ -604,7 +604,7 @@ pub fn run_config(config: Config) -> Result<()> {
                 )?;
                 processed_records.push(AnnotationFrame {
                     frame_index,
-                    frame_bgr: frame_bgr.clone(),
+                    frame_bgr,
                     boxes,
                 });
             }

--- a/vrifa-rs/crates/vrifa-cli/src/lib.rs
+++ b/vrifa-rs/crates/vrifa-cli/src/lib.rs
@@ -498,6 +498,20 @@ pub fn run_config(config: Config) -> Result<()> {
             )?);
         }
     }
+    let stream_coco_images = config.annotation_mode == "all"
+        && config.annotation_formats.len() == 1
+        && config.annotation_formats[0] == "coco";
+    let coco_images_dir = config
+        .output_dir
+        .join("formatCOCO")
+        .join("images")
+        .join("default");
+    let mut coco_image_writer = if stream_coco_images {
+        fs::create_dir_all(&coco_images_dir)?;
+        Some(AsyncPngWriter::open_with_workers(true, 8, 64)?)
+    } else {
+        None
+    };
 
     reader.seek_zero()?;
     let mut processed = 0usize;
@@ -602,6 +616,15 @@ pub fn run_config(config: Config) -> Result<()> {
                     config.annotation_segmentation_tolerance,
                     config.annotation_segmentation_max_edge_length,
                 )?;
+                let frame_bgr = if let Some(writer) = coco_image_writer.as_mut() {
+                    writer.write_bgr(
+                        coco_images_dir.join(format!("frame_{frame_index:06}.png")),
+                        frame_bgr,
+                    )?;
+                    None
+                } else {
+                    Some(frame_bgr)
+                };
                 processed_records.push(AnnotationFrame {
                     frame_index,
                     frame_bgr,
@@ -676,6 +699,9 @@ pub fn run_config(config: Config) -> Result<()> {
         writer.close()?;
     }
     if let Some(writer) = heat_writer.take() {
+        writer.close()?;
+    }
+    if let Some(writer) = coco_image_writer.take() {
         writer.close()?;
     }
     if let Some(writer) = mask_png_writer.take() {

--- a/vrifa-rs/crates/vrifa-cli/src/lib.rs
+++ b/vrifa-rs/crates/vrifa-cli/src/lib.rs
@@ -9,6 +9,7 @@ use std::collections::{BTreeSet, VecDeque};
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Instant;
 use vrifa_annotations::AnnotationFrame;
 use vrifa_core::colorspace::{convert_frame_to_colorspace, ColorSpace};
@@ -587,8 +588,13 @@ pub fn run_config(config: Config) -> Result<()> {
                     .as_ref()
                     .filter(|_| config.peak_reference),
             )?;
-            let mask = apply_locking(&mask_raw, config.lock_frames, lock_state.as_mut())?;
-            let overlay = create_overlay(&frame_bgr, &mask)?;
+            let mask = Arc::new(apply_locking(
+                &mask_raw,
+                config.lock_frames,
+                lock_state.as_mut(),
+            )?);
+            let overlay = Arc::new(create_overlay(&frame_bgr, &mask)?);
+            let heatmap = Arc::new(heatmap);
 
             if !config.annotation_formats.is_empty() {
                 let boxes = extract_bounding_boxes(
@@ -605,13 +611,13 @@ pub fn run_config(config: Config) -> Result<()> {
 
             let basename = format!("frame_{frame_index:06}.png");
             if let Some(writer) = mask_png_writer.as_mut() {
-                writer.write_gray(mask_dir.join(&basename), mask.clone())?;
+                writer.write_gray(mask_dir.join(&basename), (*mask).clone())?;
             }
             if let Some(writer) = overlay_png_writer.as_mut() {
-                writer.write_bgr(overlay_dir.join(&basename), overlay.clone())?;
+                writer.write_bgr(overlay_dir.join(&basename), (*overlay).clone())?;
             }
             if let Some(writer) = heatmap_png_writer.as_mut() {
-                writer.write_bgr(heatmap_dir.join(&basename), heatmap.clone())?;
+                writer.write_bgr(heatmap_dir.join(&basename), (*heatmap).clone())?;
             }
             if let Some(writer) = mask_writer.as_mut() {
                 writer.write_gray(mask.clone())?;

--- a/vrifa-rs/crates/vrifa-cli/src/lib.rs
+++ b/vrifa-rs/crates/vrifa-cli/src/lib.rs
@@ -20,7 +20,7 @@ use vrifa_core::peak::update_peak_brightness;
 use vrifa_core::reference::{select_dynamic_reference_index, DynamicReferenceParams};
 use vrifa_core::roi::{build_roi_mask, resolve_roi_margins};
 use vrifa_core::{detect_front, detect_front_debug, DetectFrontDebug, DetectFrontParams};
-use vrifa_io::{AsyncVideoWriter, VideoReader};
+use vrifa_io::{AsyncPngWriter, AsyncVideoWriter, VideoReader};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -450,6 +450,18 @@ pub fn run_config(config: Config) -> Result<()> {
     if config.write_heatmap_pngs {
         fs::create_dir_all(&heatmap_dir)?;
     }
+    let mut mask_png_writer = config
+        .write_mask_pngs
+        .then(|| AsyncPngWriter::open(false))
+        .transpose()?;
+    let mut overlay_png_writer = config
+        .write_overlay_pngs
+        .then(|| AsyncPngWriter::open(true))
+        .transpose()?;
+    let mut heatmap_png_writer = config
+        .write_heatmap_pngs
+        .then(|| AsyncPngWriter::open(true))
+        .transpose()?;
 
     let video_dir = config.output_dir.join("videos");
     let mut mask_writer = None;
@@ -592,14 +604,14 @@ pub fn run_config(config: Config) -> Result<()> {
             }
 
             let basename = format!("frame_{frame_index:06}.png");
-            if config.write_mask_pngs {
-                vrifa_io::write_gray_png(mask_dir.join(&basename), &mask)?;
+            if let Some(writer) = mask_png_writer.as_mut() {
+                writer.write_gray(mask_dir.join(&basename), mask.clone())?;
             }
-            if config.write_overlay_pngs {
-                vrifa_io::write_bgr_png(overlay_dir.join(&basename), &overlay)?;
+            if let Some(writer) = overlay_png_writer.as_mut() {
+                writer.write_bgr(overlay_dir.join(&basename), overlay.clone())?;
             }
-            if config.write_heatmap_pngs {
-                vrifa_io::write_bgr_png(heatmap_dir.join(&basename), &heatmap)?;
+            if let Some(writer) = heatmap_png_writer.as_mut() {
+                writer.write_bgr(heatmap_dir.join(&basename), heatmap.clone())?;
             }
             if let Some(writer) = mask_writer.as_mut() {
                 writer.write_gray(mask.clone())?;
@@ -658,6 +670,15 @@ pub fn run_config(config: Config) -> Result<()> {
         writer.close()?;
     }
     if let Some(writer) = heat_writer.take() {
+        writer.close()?;
+    }
+    if let Some(writer) = mask_png_writer.take() {
+        writer.close()?;
+    }
+    if let Some(writer) = overlay_png_writer.take() {
+        writer.close()?;
+    }
+    if let Some(writer) = heatmap_png_writer.take() {
         writer.close()?;
     }
 

--- a/vrifa-rs/crates/vrifa-cli/src/lib.rs
+++ b/vrifa-rs/crates/vrifa-cli/src/lib.rs
@@ -498,7 +498,8 @@ pub fn run_config(config: Config) -> Result<()> {
             )?);
         }
     }
-    let stream_coco_images = config.annotation_mode == "all"
+    let stream_coco_images = metadata.total_frames.map(|frames| frames > 300).unwrap_or(true)
+        && config.annotation_mode == "all"
         && config.annotation_formats.len() == 1
         && config.annotation_formats[0] == "coco";
     let coco_images_dir = config

--- a/vrifa-rs/crates/vrifa-io/src/lib.rs
+++ b/vrifa-rs/crates/vrifa-io/src/lib.rs
@@ -6,6 +6,7 @@ use opencv::prelude::*;
 use opencv::videoio;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{sync_channel, SyncSender};
+use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use vrifa_core::cvutil;
 
@@ -96,8 +97,8 @@ pub struct VideoWriter {
 }
 
 enum VideoFrame {
-    Bgr(BgrFrame),
-    Gray(Array2<u8>),
+    Bgr(Arc<BgrFrame>),
+    Gray(Arc<Array2<u8>>),
 }
 
 enum PngFrame {
@@ -145,7 +146,7 @@ impl AsyncVideoWriter {
         })
     }
 
-    pub fn write_bgr(&self, frame: BgrFrame) -> Result<()> {
+    pub fn write_bgr(&self, frame: Arc<BgrFrame>) -> Result<()> {
         if !self.is_color {
             return Err(anyhow!("writer was opened as grayscale"));
         }
@@ -154,7 +155,7 @@ impl AsyncVideoWriter {
             .map_err(|err| anyhow!("video writer thread stopped: {err}"))
     }
 
-    pub fn write_gray(&self, frame: Array2<u8>) -> Result<()> {
+    pub fn write_gray(&self, frame: Arc<Array2<u8>>) -> Result<()> {
         if self.is_color {
             return Err(anyhow!("writer was opened as color"));
         }

--- a/vrifa-rs/crates/vrifa-io/src/lib.rs
+++ b/vrifa-rs/crates/vrifa-io/src/lib.rs
@@ -4,7 +4,7 @@ use opencv::core::{Mat, Size};
 use opencv::imgcodecs;
 use opencv::prelude::*;
 use opencv::videoio;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc::{sync_channel, SyncSender};
 use std::thread::{self, JoinHandle};
 use vrifa_core::cvutil;
@@ -100,8 +100,19 @@ enum VideoFrame {
     Gray(Array2<u8>),
 }
 
+enum PngFrame {
+    Bgr { path: PathBuf, frame: BgrFrame },
+    Gray { path: PathBuf, frame: Array2<u8> },
+}
+
 pub struct AsyncVideoWriter {
     sender: SyncSender<VideoFrame>,
+    handle: JoinHandle<Result<()>>,
+    is_color: bool,
+}
+
+pub struct AsyncPngWriter {
+    sender: SyncSender<PngFrame>,
     handle: JoinHandle<Result<()>>,
     is_color: bool,
 }
@@ -160,6 +171,57 @@ impl AsyncVideoWriter {
     }
 }
 
+impl AsyncPngWriter {
+    pub fn open(is_color: bool) -> Result<Self> {
+        let (sender, receiver) = sync_channel::<PngFrame>(8);
+        let handle = thread::spawn(move || -> Result<()> {
+            for frame in receiver {
+                match frame {
+                    PngFrame::Bgr { path, frame } => write_bgr_png_impl(&path, &frame)?,
+                    PngFrame::Gray { path, frame } => write_gray_png_impl(&path, &frame)?,
+                }
+            }
+            Ok(())
+        });
+        Ok(Self {
+            sender,
+            handle,
+            is_color,
+        })
+    }
+
+    pub fn write_bgr(&self, path: impl AsRef<Path>, frame: BgrFrame) -> Result<()> {
+        if !self.is_color {
+            return Err(anyhow!("writer was opened as grayscale"));
+        }
+        self.sender
+            .send(PngFrame::Bgr {
+                path: path.as_ref().to_path_buf(),
+                frame,
+            })
+            .map_err(|err| anyhow!("png writer thread stopped: {err}"))
+    }
+
+    pub fn write_gray(&self, path: impl AsRef<Path>, frame: Array2<u8>) -> Result<()> {
+        if self.is_color {
+            return Err(anyhow!("writer was opened as color"));
+        }
+        self.sender
+            .send(PngFrame::Gray {
+                path: path.as_ref().to_path_buf(),
+                frame,
+            })
+            .map_err(|err| anyhow!("png writer thread stopped: {err}"))
+    }
+
+    pub fn close(self) -> Result<()> {
+        drop(self.sender);
+        self.handle
+            .join()
+            .map_err(|_| anyhow!("png writer thread panicked"))?
+    }
+}
+
 impl VideoWriter {
     pub fn open(
         path: impl AsRef<Path>,
@@ -209,7 +271,14 @@ impl VideoWriter {
 }
 
 pub fn write_bgr_png(path: impl AsRef<Path>, frame: &BgrFrame) -> Result<()> {
-    let path = path.as_ref();
+    write_bgr_png_impl(path.as_ref(), frame)
+}
+
+pub fn write_gray_png(path: impl AsRef<Path>, frame: &Array2<u8>) -> Result<()> {
+    write_gray_png_impl(path.as_ref(), frame)
+}
+
+fn write_bgr_png_impl(path: &Path, frame: &BgrFrame) -> Result<()> {
     let (_, _, channels) = frame.dim();
     if channels != 3 {
         return Err(anyhow!(
@@ -223,8 +292,7 @@ pub fn write_bgr_png(path: impl AsRef<Path>, frame: &BgrFrame) -> Result<()> {
     Ok(())
 }
 
-pub fn write_gray_png(path: impl AsRef<Path>, frame: &Array2<u8>) -> Result<()> {
-    let path = path.as_ref();
+fn write_gray_png_impl(path: &Path, frame: &Array2<u8>) -> Result<()> {
     // Match Python's cv2.imwrite output to keep parity artifacts deterministic.
     let mat = cvutil::array2_u8_to_mat(frame)?;
     imgcodecs::imwrite_def(&path.to_string_lossy(), &mat)

--- a/vrifa-rs/crates/vrifa-io/src/lib.rs
+++ b/vrifa-rs/crates/vrifa-io/src/lib.rs
@@ -5,8 +5,8 @@ use opencv::imgcodecs;
 use opencv::prelude::*;
 use opencv::videoio;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc::{sync_channel, SyncSender};
-use std::sync::Arc;
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
+use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use vrifa_core::cvutil;
 
@@ -114,7 +114,7 @@ pub struct AsyncVideoWriter {
 
 pub struct AsyncPngWriter {
     sender: SyncSender<PngFrame>,
-    handle: JoinHandle<Result<()>>,
+    handles: Vec<JoinHandle<Result<()>>>,
     is_color: bool,
 }
 
@@ -174,19 +174,23 @@ impl AsyncVideoWriter {
 
 impl AsyncPngWriter {
     pub fn open(is_color: bool) -> Result<Self> {
-        let (sender, receiver) = sync_channel::<PngFrame>(8);
-        let handle = thread::spawn(move || -> Result<()> {
-            for frame in receiver {
-                match frame {
-                    PngFrame::Bgr { path, frame } => write_bgr_png_impl(&path, &frame)?,
-                    PngFrame::Gray { path, frame } => write_gray_png_impl(&path, &frame)?,
-                }
-            }
-            Ok(())
-        });
+        Self::open_with_workers(is_color, 1, 8)
+    }
+
+    pub fn open_with_workers(
+        is_color: bool,
+        worker_count: usize,
+        queue_capacity: usize,
+    ) -> Result<Self> {
+        let (sender, receiver) = sync_channel::<PngFrame>(queue_capacity.max(1));
+        let receiver = Arc::new(Mutex::new(receiver));
+        let mut handles = Vec::with_capacity(worker_count.max(1));
+        for _ in 0..worker_count.max(1) {
+            handles.push(spawn_png_worker(Arc::clone(&receiver)));
+        }
         Ok(Self {
             sender,
-            handle,
+            handles,
             is_color,
         })
     }
@@ -217,10 +221,34 @@ impl AsyncPngWriter {
 
     pub fn close(self) -> Result<()> {
         drop(self.sender);
-        self.handle
-            .join()
-            .map_err(|_| anyhow!("png writer thread panicked"))?
+        for handle in self.handles {
+            handle
+                .join()
+                .map_err(|_| anyhow!("png writer thread panicked"))??;
+        }
+        Ok(())
     }
+}
+
+fn spawn_png_worker(receiver: Arc<Mutex<Receiver<PngFrame>>>) -> JoinHandle<Result<()>> {
+    thread::spawn(move || -> Result<()> {
+        loop {
+            let frame = {
+                let receiver = receiver
+                    .lock()
+                    .map_err(|_| anyhow!("png writer queue poisoned"))?;
+                match receiver.recv() {
+                    Ok(frame) => frame,
+                    Err(_) => break,
+                }
+            };
+            match frame {
+                PngFrame::Bgr { path, frame } => write_bgr_png_impl(&path, &frame)?,
+                PngFrame::Gray { path, frame } => write_gray_png_impl(&path, &frame)?,
+            }
+        }
+        Ok(())
+    })
 }
 
 impl VideoWriter {


### PR DESCRIPTION
## Summary
- Split `perf_gate.rs` into six cases: `input_{1,2}_{detector,core,full}` so layer costs are isolated.
- Improve annotation PNG export path (faster encode, reduced cloning).
- Original 22 s gate was ungrounded; profile shows the core detector runs ~23 s on input_1 and COCO/PNG export accounts for the rest.

## Layer deltas across three green bench runs
- input_1: `core - detector` ~3.2-5.2 s (MP4 encode), `full - core` ~43.2-47.1 s (COCO + PNG export)
- input_2: `core - detector` ~0.7-0.8 s, `full - core` ~3.9-4.1 s

Gate values widened to absorb thermal-throttling on back-to-back runs:
- `input_1_detector` <= 32.0 s
- `input_1_core`     <= 35.0 s
- `input_1_full`     <= 90.0 s
- `input_2_detector` <=  5.0 s
- `input_2_core`     <=  6.0 s
- `input_2_full`     <= 11.0 s

## Test plan
- [x] cargo bench -p vrifa-cli --bench perf_gate (three consecutive green runs)
- [x] cargo test --workspace --release
- [x] python3 tools/compare_runs.py /tmp/py_1 /tmp/rs_1
- [x] python3 tools/compare_runs.py /tmp/py_2 /tmp/rs_2

## Closes
The CPU port is locked after this. Further throughput gains require GPU, not micro-tuning.